### PR TITLE
Fixing broken build

### DIFF
--- a/src/lib/qml/shaders/geom/CMakeLists.txt
+++ b/src/lib/qml/shaders/geom/CMakeLists.txt
@@ -1,0 +1,3 @@
+project(feather_geom_shaders)
+FILE(GLOB GLSL_FILES "*.glsl")
+INSTALL(FILES ${GLSL_FILES} DESTINATION /usr/local/feather/shaders/geom)


### PR DESCRIPTION
Expecting this to work.

- [Template](https://github.com/feather3d/feather/wiki/Building-on-Arch-Linux)

Before this commit, this error was produced.

```
CMake Error at src/lib/qml/shaders/CMakeLists.txt:2 (add_subdirectory):
  add_subdirectory given source "geom" which is not an existing directory.
```